### PR TITLE
Update manifest for compatibility with Home Assistent 2021.6 and newer

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,5 +3,6 @@
   "name": "IMAP Attachment Sensor",
   "documentation": "https://github.com/emcniece/ha_imap_attachment",
   "requirements": [""],
-  "codeowners": ["@emcniece"]
+  "codeowners": ["@emcniece"],
+  "version": "2022.01.25"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "domain": "imap_attachment",
   "name": "IMAP Attachment Sensor",
   "documentation": "https://github.com/emcniece/ha_imap_attachment",
-  "requirements": [""],
+  "requirements": [],
   "codeowners": ["@emcniece"],
   "version": "2022.01.25"
 }


### PR DESCRIPTION
As of Home Assistant 2021.6, custom integrations require a version-property to be present in the manifest. If it is missing, the integration will no longer be loaded. This PR adds such a version-property.

There also was an error because the requirement-property was not a empty array but an array with an empty string. This may have worked with older versions of Home Assistant but is no longer valid for current versions.