### PR TITLE
Add minimal hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+  "name": "IMAP Attachment Sensor",
+  "content_in_root": true,
+  "render_readme": true
+}


### PR DESCRIPTION
This PR adds a minimal hacs.json file to make it able to install this integration as a custom repository with the [HACS](https://hacs.xyz) integration.

Why?

Because it simplifies the whole "clone the repository" > "copy it to your HA-server" workflow and updates (for people that already use the HACS integration). This integration does not need the whole "auto update" functionality therefore just the required `name` and in the case of this integration `content_in_root` property is required. `render_readme` just makes it look fancy with no additional cost ;D Updates should still be able with the "redownload" function (this should force-download the master branch so no GitHub tags for new versions are required). 

Documentation for the `hacs.json` can be found here: https://hacs.xyz/docs/publish/start#hacsjson

Installation steps: 
1. Install HACS https://hacs.xyz/docs/setup/download
2. Make sure you integrated HACS as a new device/integration in Settings.
3. Navigate to "HACS" on the side navigation.
4. Select "Integrations".
5. On the top right menu choose "Custom repositories"
6. Use the GitHub repo URL as "repository" and use category "integration" (you can use my fork where I already merged the hacs.json into the master branch) https://github.com/DarkC35/ha_imap_attachment
7. Click on the new repository "IMAP Attachment Sensor" (it should have a green border).
8. On the bottom right click "Download"

The result will look like this:
![grafik](https://user-images.githubusercontent.com/38973046/191540018-83cfe978-af6e-4157-b1a2-464ed8ae7ad4.png)
